### PR TITLE
Update cookiecutter-django workshop title

### DIFF
--- a/src/pages/schedule.js
+++ b/src/pages/schedule.js
@@ -85,7 +85,7 @@ const commonSchedule = {
             speaker: 'Max Ong',
           },
           {
-            title: 'Your first Django website with cookiecutter-django',
+            title: 'Production-ready Django project with cookiecutter',
             speaker: 'Liuyang Wan',
           },
           {


### PR DESCRIPTION
Just updating my workshop title to make it more accurate.

The material repo, in case you want to link it:
https://github.com/sfdye/pyconsg-workshop-cookiecutter-django